### PR TITLE
Fixes #26 (CompilerSettings window is sluggish when no build log exists)

### DIFF
--- a/core/UnityPackage/Assets/Editor/CompilerSettings.cs
+++ b/core/UnityPackage/Assets/Editor/CompilerSettings.cs
@@ -95,8 +95,10 @@ public class CompilerSettings : EditorWindow
 
         EditorGUILayout.BeginHorizontal();
         EditorGUILayout.LabelField("Version", GetUniversalCompilerVersion());
+        EditorGUI.BeginDisabledGroup(!File.Exists(UcLogFilePath));
         if (GUILayout.Button("Log"))
             ShowUniversalCompilerClientLog();
+        EditorGUI.EndDisabledGroup();
         EditorGUILayout.EndHorizontal();
 
         var durations = GetUniversalCompilerLastBuildLogs();
@@ -183,6 +185,10 @@ public class CompilerSettings : EditorWindow
             return _ucLastBuildLog;
 
         _ucLastBuildLog = new[] {"", "", ""};
+        if (!File.Exists(UcLogFilePath)) {
+            return _ucLastBuildLog;
+        }
+        
         try
         {
             var lines = File.ReadAllLines(UcLogFilePath);


### PR DESCRIPTION
This fixes #26.

Also added a `DisableGroup` so the `Log` button would be disabled when no log file is present.
Very minor change.