### PR TITLE
Fix compiler failing to load settings xml

### DIFF
--- a/core/IncrementalCompiler/Settings.cs
+++ b/core/IncrementalCompiler/Settings.cs
@@ -22,7 +22,7 @@ namespace IncrementalCompiler
             if (File.Exists(fileName) == false)
                 return null;
 
-            using (var stream = new FileStream(fileName, FileMode.Open))
+            using (var stream = new FileStream(fileName, FileMode.Open, FileAccess.Read, FileShare.Read))
             {
                 return Load(stream);
             }


### PR DESCRIPTION
IncrementalCompiler.exe was sometimes throwing unhandled exception when trying to load IncrementalCompiler.xml. This always resulted in an empty compiler error in Unity
Check [#28](url=https://github.com/SaladLab/Unity3D.IncrementalCompiler/issues/28)

This fixes this issue for me. Changed access mode and file share parameters when opening settings.xml. Request only read rights and allow other processes to read as well.