### PR TITLE
Mac platform fixes

### DIFF
--- a/core/IncrementalCompiler/CompilerServiceClient.cs
+++ b/core/IncrementalCompiler/CompilerServiceClient.cs
@@ -6,13 +6,8 @@ namespace IncrementalCompiler
     {
         public static CompileResult Request(int parentProcessId, string currentPath, CompileOptions options)
         {
-            var address = "net.pipe://localhost/Unity3D.IncrementalCompiler/" + parentProcessId;
-
-            var binding = new NetNamedPipeBinding(NetNamedPipeSecurityMode.None)
-            {
-                MaxBufferSize = int.MaxValue,
-                MaxReceivedMessageSize = int.MaxValue
-            };
+            var address = CompilerServiceHelper.BaseAddress + parentProcessId;
+            var binding = CompilerServiceHelper.GetBinding();
             var ep = new EndpointAddress(address);
             var channel = ChannelFactory<ICompilerService>.CreateChannel(binding, ep);
             return channel.Build(currentPath, options);

--- a/core/IncrementalCompiler/CompilerServiceHelper.cs
+++ b/core/IncrementalCompiler/CompilerServiceHelper.cs
@@ -1,0 +1,39 @@
+﻿using System.ServiceModel;
+using System.ServiceModel.Channels;
+
+namespace IncrementalCompiler
+{
+    public static class CompilerServiceHelper
+    {
+        private static string winAddress = "net.pipe://localhost/Unity3D.IncrementalCompiler/";
+        private static string macAddress = "http://localhost:52000/Unity3D.IncrementalCompiler/";
+
+        public static string BaseAddress
+        {
+            get
+            {
+                return PlatformHelper.CurrentPlatform == Platform.Mac ? macAddress : winAddress;
+            }
+        }
+
+        public static Binding GetBinding()
+        {
+            if (PlatformHelper.CurrentPlatform == Platform.Mac)
+            {
+                return new BasicHttpBinding(BasicHttpSecurityMode.None)
+                {
+                    MaxBufferSize = int.MaxValue,
+                    MaxReceivedMessageSize = int.MaxValue
+                };
+            }
+            else
+            {
+                return new NetNamedPipeBinding(NetNamedPipeSecurityMode.None)
+                {
+                    MaxBufferSize = int.MaxValue,
+                    MaxReceivedMessageSize = int.MaxValue
+                };
+            }
+        }
+    }
+}

--- a/core/IncrementalCompiler/CompilerServiceServer.cs
+++ b/core/IncrementalCompiler/CompilerServiceServer.cs
@@ -1,12 +1,16 @@
 ﻿using System;
 using System.Diagnostics;
 using System.ServiceModel;
+using System.Threading;
 using NLog;
 
 namespace IncrementalCompiler
 {
     public class CompilerServiceServer
     {
+
+        private static ServiceHost serviceHost;
+
         public static int Run(Logger logger, int parentProcessId)
         {
             // get parent process which will be monitored
@@ -29,25 +33,40 @@ namespace IncrementalCompiler
 
             try
             {
-                var address = "net.pipe://localhost/Unity3D.IncrementalCompiler/" + parentProcessId;
-                var serviceHost = new ServiceHost(typeof(CompilerService));
-                var binding = new NetNamedPipeBinding(NetNamedPipeSecurityMode.None)
-                {
-                    MaxBufferSize = int.MaxValue,
-                    MaxReceivedMessageSize = int.MaxValue
-                };
+                var address = CompilerServiceHelper.BaseAddress + parentProcessId;
+                serviceHost = new ServiceHost(typeof(CompilerService));
+                var binding = CompilerServiceHelper.GetBinding();
                 serviceHost.AddServiceEndpoint(typeof(ICompilerService), binding, address);
                 serviceHost.Open();
             }
             catch (Exception e)
             {
+                if (serviceHost != null)
+                {
+                    serviceHost.Close();
+                }
                 logger.Error(e, "Service Host got an error");
                 return 1;
             }
 
             if (parentProcess != null)
             {
-                parentProcess.WaitForExit();
+                //WaitForExit returns immediately instead of waiting on Mac so use while loop
+                if (PlatformHelper.CurrentPlatform == Platform.Mac)
+                {
+                    while (!parentProcess.HasExited)
+                    {
+                        Thread.Sleep(100);
+                    }
+                }
+                else
+                {
+                    parentProcess.WaitForExit();
+                }
+                if (serviceHost != null)
+                {
+                    serviceHost.Close();
+                }
                 logger.Info("Parent process just exited. (PID={0})", parentProcess.Id);
             }
 

--- a/core/IncrementalCompiler/IncrementalCompiler.csproj
+++ b/core/IncrementalCompiler/IncrementalCompiler.csproj
@@ -71,8 +71,10 @@
     <Compile Include="CompileResult.cs" />
     <Compile Include="CompilerService.cs" />
     <Compile Include="CompilerServiceClient.cs" />
+    <Compile Include="CompilerServiceHelper.cs" />
     <Compile Include="CompilerServiceServer.cs" />
     <Compile Include="FileTimeList.cs" />
+    <Compile Include="PlatformHelper.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Program.Dev.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/core/IncrementalCompiler/PlatformHelper.cs
+++ b/core/IncrementalCompiler/PlatformHelper.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.IO;
+
+namespace IncrementalCompiler
+{
+    public static class PlatformHelper
+    {
+        public static Platform CurrentPlatform
+        {
+            get
+            {
+                switch (Environment.OSVersion.Platform)
+                {
+                    case PlatformID.Unix:
+                        // Well, there are chances MacOSX is reported as Unix instead of MacOSX.
+                        // Instead of platform check, we'll do a feature checks (Mac specific root folders)
+                        if (Directory.Exists("/Applications")
+                            & Directory.Exists("/System")
+                            & Directory.Exists("/Users")
+                            & Directory.Exists("/Volumes"))
+                        {
+                            return Platform.Mac;
+                        }
+                        return Platform.Linux;
+
+                    case PlatformID.MacOSX:
+                        return Platform.Mac;
+
+                    default:
+                        return Platform.Windows;
+                }
+            }
+        }
+    }
+
+    public enum Platform
+    {
+        Windows,
+        Linux,
+        Mac
+    }
+}


### PR DESCRIPTION
- Using BasicHttpBinding instead of NetNamedPipeBinding
- Using busy wait instead of process.WaitForExit